### PR TITLE
Fix QString::arg: Argument missing warning

### DIFF
--- a/src/qt/forms/intro.ui
+++ b/src/qt/forms/intro.ui
@@ -20,7 +20,7 @@
       <string notr="true">QLabel { font-style:italic; }</string>
      </property>
      <property name="text">
-      <string>Welcome to XSN Core.</string>
+      <string>Welcome to %1.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -46,7 +46,7 @@
    <item>
     <widget class="QLabel" name="storageLabel">
      <property name="text">
-      <string>As this is the first time the program is launched, you can choose where XSN Core will store its data.</string>
+      <string>As this is the first time the program is launched, you can choose where %1 will store its data.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -55,9 +55,6 @@
    </item>
    <item>
     <widget class="QLabel" name="sizeWarningLabel">
-     <property name="text">
-      <string>XSN Core will download and store a copy of the XSN block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</string>
-     </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
Simple fix for warning when starting qt