### PR TITLE
avoid interger rounding 

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -1045,9 +1045,8 @@ void AdjustMasternodePayment(CMutableTransaction &tx, const CTxOut &txoutMastern
         int i = tx.vout.size() - 2;
         if(tposContract.IsValid()) // here we have 3 outputs, first as stake reward, second as tpos reward, third as MN reward
         {
-            masternodePayment /= 100; // to calculate percentage
-            tx.vout[i - 1].nValue -= masternodePayment * tposContract.stakePercentage; // adjust reward for owner.
-            tx.vout[i].nValue -= masternodePayment * (100 - tposContract.stakePercentage); // adjust reward for merchant
+            tx.vout[i - 1].nValue -= masternodePayment * tposContract.stakePercentage / 100; // adjust reward for owner.
+            tx.vout[i].nValue -= masternodePayment * (100 - tposContract.stakePercentage) / 100; // adjust reward for merchant
         }
         else // here we have 2 outputs, first as stake reward, second as MN reward
         {

--- a/src/tpos/tposutils.cpp
+++ b/src/tpos/tposutils.cpp
@@ -347,7 +347,7 @@ bool TPoSUtils::IsMerchantPaymentValid(CValidationState &state, const CBlock &bl
 
     if(merchantPayment > 0)
     {
-        auto maxAllowedValue = (expectedReward / 100) * (100 - contract.stakePercentage);
+        auto maxAllowedValue = expectedReward * (100 - contract.stakePercentage) / 100;
         // ban, we know fur sure that merchant tries to get more than he is allowed
         if(merchantPayment > maxAllowedValue)
             return state.DoS(100, error("IsMerchantPaymentValid -- ERROR: merchant was paid more than allowed: %s\n", contract.merchantAddress.ToString().c_str()),

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -397,7 +397,7 @@ bool CWallet::AddWatchOnly(const CScript& dest)
 
 CAmount GetStakeReward(CAmount blockReward, unsigned int percentage)
 {
-    return (blockReward / 100) * percentage;
+    return blockReward * percentage / 100;
 }
 
 bool CWallet::CreateCoinStakeKernel(CScript &kernelScript, const CScript &stakeScript,


### PR DESCRIPTION
Two significant digits were lost during percentage based tpos reward calculations due to integer rounding. Should multiply first and then divide.

Problem:
A reward value of 1.23456789 encoded as int (CAmount): 123456789
123456789 / 100 becomes 1234567, information about the digits '89' is lost

I also don't see overflow becoming an issue currently.