### PR TITLE
chore(Dockerfile): update Dockerfile to reduze image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,102 @@
-FROM debian:stretch
+FROM debian:stretch-slim as build-layer
 
-# Install required system packages
-RUN apt-get update && apt-get install -y \
-    apt-utils \
-    automake \
-    g++ \
-    make \
-    libtool \
-    pkg-config \
-    doxygen \
-    libdb++-dev \
-    curl \
-    bsdmainutils \
-    libboost-all-dev \
-    libssl-dev \
-    libevent-dev
+LABEL maintainer="Peponi <pep0ni@pm.com>" \
+      description="will compile & run (Stakenet) xsnd"
 
-# Install Berkeley DB 4.8
-RUN curl -L http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz | tar -xz -C /tmp && \
-    cd /tmp/db-4.8.30/build_unix && \
-    ../dist/configure --enable-cxx --includedir=/usr/include/bdb4.8 --libdir=/usr/lib && \
-    make -j$(nproc) && make install && \
-    cd / && rm -rf /tmp/db-4.8.30
+ARG BERKELEYDB_URL="http://download.oracle.com/berkeley-db/"
+ARG BERKELEYDB_VERSION="db-4.8.30"
+ARG DEFAULT_PORT="62583"
+ARG MAINNET_PORT="8332"
+ARG TESTNET_PORT="18332"
 
-RUN useradd -mU xsn
+ENV BERKELEYDB_VERSION=$BERKELEYDB_VERSION \
+    BERKELEYDB_URL=$BERKELEYDB_URL \
+    PKG_URL=$BERKELEYDB_URL$BERKELEYDB_VERSION \
+    DEFAULT_PORT=$DEFAULT_PORT \
+    MAINNET_PORT=$MAINNET_PORT \
+    TESTNET_PORT=$TESTNET_PORT
 
 COPY . /tmp/xsncore/
 
-RUN cd /tmp/xsncore && \
-    ./autogen.sh && \
-    ./configure --without-gui --prefix=/usr && \
-    make -j$(nproc) && \
-    make check && \
-    make install && \
-    cd / && rm -rf /tmp/xsncore
+# Install required system packages
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+        apt-utils \
+        curl \
+        g++ \
+        make \
+        automake \
+        pkg-config \
+        doxygen \
+        bsdmainutils \
+        libtool \
+        libdb++-dev \
+        libboost-system-dev \
+        libboost-filesystem-dev \
+        libboost-chrono-dev \
+        libboost-program-options-dev \
+        libboost-test-dev \
+        libboost-thread-dev \
+        libssl-dev \
+        libevent-dev \
+# Install Berkeley DB
+    && curl -kL $PKG_URL.tar.gz | tar -xz -C /tmp \
+    && cd /tmp/$BERKELEYDB_VERSION/build_unix \
+    && ../dist/configure --enable-cxx --includedir=/usr/include/bdb4.8 --libdir=/usr/lib \
+# fix error in compile log, as done in https://hub.docker.com/r/lncm/berkeleydb/dockerfile
+    && sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i /tmp/$BERKELEYDB_VERSION/dbinc/atomic.h \
+    && make -j$(nproc) \
+    && make install \
+    && cd /tmp/xsncore \
+# Install xsnd
+    && ./autogen.sh \
+    && ./configure --without-gui --prefix=/usr \
+    && make -j$(nproc) \
+    && make check \
+    && make install \
+    && apt-get purge -y \
+        apt-utils \
+        curl \
+        g++ \
+        make \
+        automake \
+        pkg-config \
+        doxygen \
+        bsdmainutils \
+        libtool \
+        libdb++-dev \
+        libboost-system-dev \
+        libboost-filesystem-dev \
+        libboost-chrono-dev \
+        libboost-program-options-dev \
+        libboost-test-dev \
+        libboost-thread-dev \
+        libssl-dev \
+        libevent-dev
 
-# Remove unused packages
-RUN apt-get remove -y \
-    automake \
-    g++ \
-    make \
-    libtool \
-    pkg-config \
-    doxygen \
-    libdb++-dev \
-    curl \
-    bsdmainutils \
-    libboost-all-dev \
-    libssl-dev \
-    libevent-dev
+FROM debian:stretch-slim
 
-USER xsn:xsn
+COPY --from=build-layer /usr/bin/*xsn /usr/bin/
+COPY --from=build-layer /usr/bin/xsn* /usr/bin/
+COPY --from=build-layer /usr/lib/libdb* /usr/lib/
+COPY --from=build-layer /usr/lib/pkgconfig/* /usr/lib/pkgconfig/
+COPY --from=build-layer /usr/include/xsn* /usr/include/
 
-RUN mkdir /home/xsn/.xsncore && \
-    touch /home/xsn/.xsncore/xsn.conf
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install --no-install-recommends --no-install-suggests -y curl \
+    && useradd -mU xsn \
+    && mkdir /home/xsn/.xsncore \
+    && touch /home/xsn/.xsncore/xsn.conf \
+    && chown -R xsn:xsn /home/xsn/.xsncore
+
+USER xsn:xsn    
 
 VOLUME [ "/home/xsn/.xsncore" ]
 
-EXPOSE 62583
-EXPOSE 8332
-EXPOSE 18332
+EXPOSE $DEFAULT_PORT $MAINNET_PORT $TESTNET_PORT
 
 ENTRYPOINT ["/usr/bin/xsnd", "--conf=/home/xsn/.xsncore/xsn.conf"]
+
+HEALTHCHECK CMD curl --fail http://127.0.0.1:$DEFAULT_PORT/ || exit 1


### PR DESCRIPTION
and hopfully traffic & copy time on some the CI (^_^)

INFO: safed 923MB of the images size


| REPOSITORY |   TAG   |    IMAGE ID   |    CREATED    |   SIZE  |
|------------|---------|---------------|---------------|---------|
| xsn        |  own    |  c8423e5bf760 |  6 hours ago  |  757MB  |
| xsn        |  latest |  10e6227772e4 |  32 hours ago |  1.86GB |

-------------------

INFO: this version based on *"debian:stretch-slim"*

have tried to build a version on "debian:buster-slim" to reduze the security issues amount


|   debian    | image-size | trivy security | low | mediam | high |
|-------------|------------|----------------|-----|--------|------|
| strech-slim | 757MB      |                | 143 |     46 |   24 |
| buseer-slim | 1.13GB     |                |  86 |     22 |    1 |

but the buster-slim version won't run

```shell
$ docker run -it --rm -p 62583:62583 xsn:own-buster
/usr/bin/xsnd: error while loading shared libraries: libboost_system.so.1.67.0: cannot open shared object file: No such file or directory
```