### PR TITLE
Revert "chore(Dockerfile): update Dockerfile to reduze image size (#1…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,101 +1,65 @@
-FROM debian:stretch-slim as build-layer
+FROM debian:stretch
 
-LABEL maintainer="Peponi <pep0ni@pm.com>" \
-      description="will compile & run (Stakenet) xsnd"
+# Install required system packages
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    automake \
+    g++ \
+    make \
+    libtool \
+    pkg-config \
+    doxygen \
+    libdb++-dev \
+    curl \
+    bsdmainutils \
+    libboost-all-dev \
+    libssl-dev \
+    libevent-dev
 
-ARG BERKELEYDB_URL="http://download.oracle.com/berkeley-db/"
-ARG BERKELEYDB_VERSION="db-4.8.30"
-ARG DEFAULT_PORT="62583"
-ARG MAINNET_PORT="8332"
-ARG TESTNET_PORT="18332"
+# Install Berkeley DB 4.8
+RUN curl -L http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz | tar -xz -C /tmp && \
+    cd /tmp/db-4.8.30/build_unix && \
+    ../dist/configure --enable-cxx --includedir=/usr/include/bdb4.8 --libdir=/usr/lib && \
+    make -j$(nproc) && make install && \
+    cd / && rm -rf /tmp/db-4.8.30
 
-ENV BERKELEYDB_VERSION=$BERKELEYDB_VERSION \
-    BERKELEYDB_URL=$BERKELEYDB_URL \
-    PKG_URL=$BERKELEYDB_URL$BERKELEYDB_VERSION \
-    DEFAULT_PORT=$DEFAULT_PORT \
-    MAINNET_PORT=$MAINNET_PORT \
-    TESTNET_PORT=$TESTNET_PORT
+RUN useradd -mU xsn
 
 COPY . /tmp/xsncore/
 
-# Install required system packages
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends --no-install-suggests -y \
-        apt-utils \
-        curl \
-        g++ \
-        make \
-        automake \
-        pkg-config \
-        doxygen \
-        bsdmainutils \
-        libtool \
-        libdb++-dev \
-        libboost-system-dev \
-        libboost-filesystem-dev \
-        libboost-chrono-dev \
-        libboost-program-options-dev \
-        libboost-test-dev \
-        libboost-thread-dev \
-        libssl-dev \
-        libevent-dev \
-# Install Berkeley DB
-    && curl -kL $PKG_URL.tar.gz | tar -xz -C /tmp \
-    && cd /tmp/$BERKELEYDB_VERSION/build_unix \
-    && ../dist/configure --enable-cxx --includedir=/usr/include/bdb4.8 --libdir=/usr/lib \
-# fix error in compile log, as done in https://hub.docker.com/r/lncm/berkeleydb/dockerfile
-    && sed s/__atomic_compare_exchange/__atomic_compare_exchange_db/g -i /tmp/$BERKELEYDB_VERSION/dbinc/atomic.h \
-    && make -j$(nproc) \
-    && make install \
-    && cd /tmp/xsncore \
-# Install xsnd
-    && ./autogen.sh \
-    && ./configure --disable-tests --without-gui --prefix=/usr \
-    && make -j$(nproc) \
-    && make check \
-    && make install \
-    && apt-get purge -y \
-        apt-utils \
-        curl \
-        g++ \
-        make \
-        automake \
-        pkg-config \
-        doxygen \
-        bsdmainutils \
-        libtool \
-        libdb++-dev \
-        libboost-system-dev \
-        libboost-filesystem-dev \
-        libboost-chrono-dev \
-        libboost-program-options-dev \
-        libboost-test-dev \
-        libboost-thread-dev \
-        libssl-dev \
-        libevent-dev
+RUN cd /tmp/xsncore && \
+    ./autogen.sh && \
+    ./configure --disable-tests --without-gui --prefix=/usr && \
+    make -j$(nproc) && \
+    make check && \
+    make install && \
+    cd / && rm -rf /tmp/xsncore
 
-FROM debian:stretch-slim
+# Remove unused packages
+RUN apt-get remove -y \
+    automake \
+    g++ \
+    make \
+    libtool \
+    pkg-config \
+    doxygen \
+    libdb++-dev \
+    curl \
+    bsdmainutils \
+    libboost-all-dev \
+    libssl-dev \
+    libevent-dev
 
-COPY --from=build-layer /usr/bin/*xsn /usr/bin/
-COPY --from=build-layer /usr/bin/xsn* /usr/bin/
-COPY --from=build-layer /usr/lib/libdb* /usr/lib/
-COPY --from=build-layer /usr/lib/pkgconfig/* /usr/lib/pkgconfig/
-COPY --from=build-layer /usr/include/xsn* /usr/include/
+USER xsn:xsn
 
-RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install --no-install-recommends --no-install-suggests -y curl \
-    && useradd -mU xsn \
-    && mkdir /home/xsn/.xsncore \
-    && touch /home/xsn/.xsncore/xsn.conf \
-    && chown -R xsn:xsn /home/xsn/.xsncore
-
-USER xsn:xsn    
+RUN mkdir /home/xsn/.xsncore && \
+    touch /home/xsn/.xsncore/xsn.conf
 
 VOLUME [ "/home/xsn/.xsncore" ]
 
-EXPOSE $DEFAULT_PORT $MAINNET_PORT $TESTNET_PORT
+EXPOSE 62583
+EXPOSE 8332
+EXPOSE 18332
 
 ENTRYPOINT ["/usr/bin/xsnd", "--conf=/home/xsn/.xsncore/xsn.conf"]
 


### PR DESCRIPTION
…49)"

This reverts commit 9ea8d9c4398c5b942ea76a656f776dfcabea2036.

Apparently, this new approach has a problem, reverting it to the bigger image gets the image back to work again:
- /usr/bin/xsnd: error while loading shared libraries: libboost_system.so.1.62.0: cannot open shared object file: No such file or directory