### PR TITLE
Update .gitattributes line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@ src/clientversion.cpp export-subst
 *.exe filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.tar.gz filter=lfs diff=lfs merge=lfs -text
+*.sh     -lf
+*.ac     -lf
+*.am     -lf


### PR DESCRIPTION
Change .gitattributes line ending for Unix-style for some extentions to avoid docker build issues on the Windows when the line ending is set to Windows style in git conf.