### PR TITLE
#167: fixed key_io tests according to new RegTestNet parameters; fixed versionbits test

### DIFF
--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -32,7 +32,7 @@
         }
     ],
     [
-        "yLpBNgQJ5JTscXeekbpcwiHZNg1m8qjuMu",
+        "XbBaMjKrdkooGnj7BkWDugsD6PXPaBdSqP",
         "76a914056f2539183089cc50d1f5cae371fc9ecf2cb46b88ac",
         {
             "isPrivkey": false,
@@ -67,7 +67,7 @@
         }
     ],
     [
-        "92Zfnv1FUSkFHk48qM4iJn4Htu4DoMBwg56RD273mi3GVV7Nuqm",
+        "7rXccoJ8eZ5Ka2iT74LjvZ5BquW63hhJ8hcefn2fymohDgDjcWc",
         "80dce57bc6b7513c0fc60d5a84b27ee29583ecfe5bc1fca473e54c44f6493d55",
         {
             "isCompressed": false,
@@ -85,7 +85,7 @@
         }
     ],
     [
-        "cNFu7Njz6kaPg3CkR7nDSnQFASMVBoKrdku5At9XNRUEsJHXDqsv",
+        "XBxq6j8VyNWaZvjs4Txxah6CTEKey9qQwJ6Waz2DBg6L1iP8ZA1g",
         "142a2c847173813e9f87d71ae8f5341c769b2799090afa19af4882174cb1cbf8",
         {
             "isCompressed": true,
@@ -289,7 +289,7 @@
         }
     ],
     [
-        "92Y52o4EtKzfvxnheMtB7sVdKJHaELtn7trYSU9YwfoJdGMfWe7",
+        "7rW1rgM84SKkDFT1v5ACjeWXGJjSUhQ8aXNmuE5B9jZjMSgtuek",
         "7d3b3e572569195bcdd263383f4962943be87f4780b7eb7e2335a9807b663073",
         {
             "isCompressed": false,
@@ -468,7 +468,7 @@
         }
     ],
     [
-        "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080",
+        "xc1qw508d6qejxtdg4y5r3zarvary0c5xw7k0ahjt8",
         "0014751e76e8199196d454941c45d1b3a323f1433bd6",
         {
             "isPrivkey": false,
@@ -504,7 +504,7 @@
         }
     ],
     [
-        "bcrt1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvseswlauz7",
+        "xc1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvseswp80ag",
         "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
         {
             "isPrivkey": false,

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -102,7 +102,7 @@ public:
         for (int i = 0; i < CHECKERS; i++) {
             if (InsecureRandBits(i) == 0) {
                 BOOST_CHECK_MESSAGE(checker[i].GetStateFor(vpblock.empty() ? nullptr : vpblock.back()) == ThresholdState::DEFINED, strprintf("Test %i for DEFINED", num));
-                BOOST_CHECK_MESSAGE(checker_always[i].GetStateFor(vpblock.empty() ? nullptr : vpblock.back()) == ThresholdState::ACTIVE, strprintf("Test %i for ACTIVE (always active)", num));
+                BOOST_CHECK_MESSAGE(vpblock.empty() || checker_always[i].GetStateFor(vpblock.back()) == ThresholdState::ACTIVE, strprintf("Test %i for ACTIVE (always active)", num));
             }
         }
         num++;

--- a/src/tpos/tposutils.cpp
+++ b/src/tpos/tposutils.cpp
@@ -157,6 +157,7 @@ bool TPoSUtils::CreateTPoSTransaction(CWallet *wallet,
         return false;
     }
 
+    LOCK2(cs_main, wallet->cs_wallet);
     if(!wallet->SignTransaction(baseTx)) {
         strError = "Failed to sign transaction after filling";
         return false;


### PR DESCRIPTION
1) Updated tests for RegTestNet (changed [in this PR](https://github.com/X9Developers/XSN/commit/0ef2ddb38866471cf73f791e18f5de7b784a91ec#diff-ff53e63501a5e89fd650b378c9708274df8ad5d38fcffa6c64be417c4d438b6dL425))
2) Removed testing of the condition "GetStateFor(nullptr) is ALWAYS_ACTIVE" (otherwise it fails because of [this modification](https://github.com/X9Developers/XSN/commit/0ef2ddb38866471cf73f791e18f5de7b784a91ec#diff-51f2f6d85b4ea5495a71bde76b5b721a5b0d2871e0912e83ff9cbb3970a7e207R31))
3) Added missed lock (thread safety analysis in cross-compilation for OS X found it)